### PR TITLE
Fix double spacing in early-release warning message.

### DIFF
--- a/src/main/java/me/desht/pneumaticcraft/common/EventHandlerPneumaticCraft.java
+++ b/src/main/java/me/desht/pneumaticcraft/common/EventHandlerPneumaticCraft.java
@@ -106,8 +106,8 @@ public class EventHandlerPneumaticCraft {
     @SubscribeEvent
     public void onPlayerLoggedIn(PlayerEvent.PlayerLoggedInEvent event) {
         event.player.sendStatusMessage(new TextComponentString(
-                TextFormatting.RED + "PneumaticCraft is in unstable pre-release status at this time. " +
-                        "While functionally complete, bugs are likely!"), false);
+                TextFormatting.RED + "PneumaticCraft is in unstable pre-release status at this time.\n" +
+                TextFormatting.RED + "While functionally complete, bugs are likely!"), false);
     }
 
     @SubscribeEvent

--- a/src/main/java/me/desht/pneumaticcraft/common/EventHandlerPneumaticCraft.java
+++ b/src/main/java/me/desht/pneumaticcraft/common/EventHandlerPneumaticCraft.java
@@ -106,7 +106,7 @@ public class EventHandlerPneumaticCraft {
     @SubscribeEvent
     public void onPlayerLoggedIn(PlayerEvent.PlayerLoggedInEvent event) {
         event.player.sendStatusMessage(new TextComponentString(
-                TextFormatting.RED + "PneumaticCraft is in unstable pre-release status at this time.  " +
+                TextFormatting.RED + "PneumaticCraft is in unstable pre-release status at this time. " +
                         "While functionally complete, bugs are likely!"), false);
     }
 


### PR DESCRIPTION
This fixes the weird-looking and unaligned message formatting in chat for the warning message.