### PR TITLE
CraftTweaker support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,10 @@ repositories {
         name = "tterrag maven"
         url = "http://maven.tterrag.com/"
     }
+    maven {
+        name 'BlameJared - Crafttweaker'
+        url 'http://maven.blamejared.com/'
+    }
 }
 
 task copyCIArtifacts << {
@@ -91,6 +95,9 @@ dependencies {
     deobfCompile "dan200.computercraft:ComputerCraft-SquidDev-CC-ComputerCraft-feature-minecraft-1.12.2:${computercraft_version}"
     deobfCompile "mcp.mobius.waila:Hwyla:${hwyla_version}"
     deobfCompile "mcjty.theoneprobe:TheOneProbe-1.12:${top_version}"
+	deobfProvided "CraftTweaker2:CraftTweaker2-API:${crafttweaker_version}"
+	runtime "CraftTweaker2:CraftTweaker2-MC1120-Main:1.12-${crafttweaker_version}"
+	deobfCompile "com.blamejared:MTLib:${mtlib_version}"
     // compile "igwmod:IGW-Mod-1.9.4:1.3.0-5:userdev"
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -27,3 +27,5 @@ oc_version=1.7.0.20
 computercraft_version=1.80pr0-build20
 hwyla_version=1.8.21-B36_1.12
 top_version=1.12-1.4.18-10
+crafttweaker_version=4.0.9.285
+mtlib_version=3.0.1.3

--- a/src/main/java/me/desht/pneumaticcraft/common/thirdparty/ThirdPartyManager.java
+++ b/src/main/java/me/desht/pneumaticcraft/common/thirdparty/ThirdPartyManager.java
@@ -8,6 +8,7 @@ import me.desht.pneumaticcraft.common.thirdparty.buildcraft.BuildCraft;
 import me.desht.pneumaticcraft.common.thirdparty.cofhcore.CoFHCore;
 import me.desht.pneumaticcraft.common.thirdparty.computercraft.ComputerCraft;
 import me.desht.pneumaticcraft.common.thirdparty.computercraft.OpenComputers;
+import me.desht.pneumaticcraft.common.thirdparty.crafttweaker.CraftTweaker;
 import me.desht.pneumaticcraft.common.thirdparty.enderio.EnderIO;
 import me.desht.pneumaticcraft.common.thirdparty.forestry.Forestry;
 import me.desht.pneumaticcraft.common.thirdparty.igwmod.IGWMod;
@@ -58,6 +59,7 @@ public class ThirdPartyManager implements IGuiHandler {
             thirdPartyClasses.put(ModIds.COFH_CORE, CoFHCore.class);
             thirdPartyClasses.put(ModIds.WAILA, Waila.class);
             thirdPartyClasses.put(ModIds.TOP, TheOneProbe.class);
+            thirdPartyClasses.put(ModIds.CRAFTTWEAKER, CraftTweaker.class);
             // thirdPartyClasses.put(ModIds.INDUSTRIALCRAFT, IC2.class);
             // thirdPartyClasses.put(ModIds.THAUMCRAFT, Thaumcraft.class);
         } catch (Throwable e) {

--- a/src/main/java/me/desht/pneumaticcraft/common/thirdparty/crafttweaker/CraftTweaker.java
+++ b/src/main/java/me/desht/pneumaticcraft/common/thirdparty/crafttweaker/CraftTweaker.java
@@ -1,9 +1,18 @@
 package me.desht.pneumaticcraft.common.thirdparty.crafttweaker;
 
+import java.util.LinkedList;
+import java.util.List;
+
+import crafttweaker.CraftTweakerAPI;
+import crafttweaker.IAction;
 import me.desht.pneumaticcraft.common.thirdparty.IThirdParty;
 
 public class CraftTweaker implements IThirdParty {
 	
+    public static final List<IAction> REMOVALS = new LinkedList<>();
+    public static final List<IAction> ADDITIONS = new LinkedList<>();
+
+
     @Override
     public void preInit() {
     }
@@ -14,6 +23,8 @@ public class CraftTweaker implements IThirdParty {
 
     @Override
     public void postInit() {
+    	REMOVALS.forEach(CraftTweakerAPI::apply);
+    	ADDITIONS.forEach(CraftTweakerAPI::apply);
     }
 
     @Override

--- a/src/main/java/me/desht/pneumaticcraft/common/thirdparty/crafttweaker/CraftTweaker.java
+++ b/src/main/java/me/desht/pneumaticcraft/common/thirdparty/crafttweaker/CraftTweaker.java
@@ -1,0 +1,27 @@
+package me.desht.pneumaticcraft.common.thirdparty.crafttweaker;
+
+import me.desht.pneumaticcraft.common.thirdparty.IThirdParty;
+
+public class CraftTweaker implements IThirdParty {
+	
+    @Override
+    public void preInit() {
+    }
+
+    @Override
+    public void init() {
+    }
+
+    @Override
+    public void postInit() {
+    }
+
+    @Override
+    public void clientSide() {
+    }
+
+    @Override
+    public void clientInit() {
+    }
+
+}

--- a/src/main/java/me/desht/pneumaticcraft/common/thirdparty/crafttweaker/handlers/Assembly.java
+++ b/src/main/java/me/desht/pneumaticcraft/common/thirdparty/crafttweaker/handlers/Assembly.java
@@ -1,0 +1,146 @@
+package me.desht.pneumaticcraft.common.thirdparty.crafttweaker.handlers;
+
+import java.util.List;
+
+import com.blamejared.mtlib.helpers.InputHelper;
+import com.blamejared.mtlib.helpers.LogHelper;
+import com.blamejared.mtlib.helpers.StackHelper;
+import com.blamejared.mtlib.utils.BaseListAddition;
+import com.blamejared.mtlib.utils.BaseListRemoval;
+
+import crafttweaker.annotations.ModOnly;
+import crafttweaker.annotations.ZenRegister;
+import crafttweaker.api.item.IIngredient;
+import crafttweaker.api.item.IItemStack;
+import me.desht.pneumaticcraft.common.recipes.AssemblyRecipe;
+import me.desht.pneumaticcraft.common.thirdparty.crafttweaker.CraftTweaker;
+import me.desht.pneumaticcraft.common.thirdparty.crafttweaker.util.RemoveAllRecipes;
+import stanhebben.zenscript.annotations.ZenClass;
+import stanhebben.zenscript.annotations.ZenMethod;
+
+@ZenClass("mods.pneumaticcraft.assembly")
+@ModOnly("mtlib")
+@ZenRegister
+public class Assembly {
+	public static final String name = "PneumaticCraft Assembly";
+	public static final String nameLaser = "PneumaticCraft Assembly (Laser)";
+	public static final String nameDrill = "PneumaticCraft Assembly (Drill)";
+	public static final String nameDrillLaser = "PneumaticCraft Assembly (Drill Laser)";
+	
+    @ZenMethod
+    public static void addDrillRecipe(IItemStack input, IItemStack output) {
+        addRecipe(nameDrill, input, output, AssemblyRecipe.drillRecipes);
+    }
+
+    @ZenMethod
+    public static void addLaserRecipe(IItemStack input, IItemStack output) {
+        addRecipe(nameLaser, input, output, AssemblyRecipe.laserRecipes);
+    }
+
+    @ZenMethod
+    public static void addDrillLaserRecipe(IItemStack input, IItemStack output) {
+        addRecipe(nameDrillLaser, input, output, AssemblyRecipe.drillLaserRecipes);
+    }
+    
+    @ZenMethod
+    public static void removeDrillRecipe(IIngredient output) {
+        removeRecipe(nameDrill, AssemblyRecipe.drillRecipes, output);
+    }
+
+    @ZenMethod
+    public static void removeAllDrillRecipes() {
+        CraftTweaker.REMOVALS.add(new RemoveAllRecipes<AssemblyRecipe>(nameDrill, AssemblyRecipe.drillRecipes));
+    }
+
+    @ZenMethod
+    public static void removeLaserRecipe(IIngredient output) {
+        removeRecipe(nameLaser, AssemblyRecipe.laserRecipes, output);
+    }
+    
+    @ZenMethod
+    public static void removeAllLaserRecipes() {
+        CraftTweaker.REMOVALS.add(new RemoveAllRecipes<AssemblyRecipe>(nameLaser, AssemblyRecipe.laserRecipes));
+    }
+
+    @ZenMethod
+    public static void removeDrillLaserRecipe(IIngredient output) {
+        removeRecipe(nameDrillLaser, AssemblyRecipe.drillLaserRecipes, output);
+    }
+    
+    @ZenMethod
+    public static void removeAllDrillLaserRecipes() {
+        CraftTweaker.REMOVALS.add(new RemoveAllRecipes<AssemblyRecipe>(nameDrillLaser, AssemblyRecipe.drillLaserRecipes));
+    }
+    
+    @ZenMethod
+    public static void removeAllRecipes() {
+    	removeAllDrillRecipes();
+    	removeAllLaserRecipes();
+    	removeAllDrillLaserRecipes();
+    }
+    
+    public static void addRecipe(String name, IItemStack input, IItemStack output, List<AssemblyRecipe> list) {
+        if(input == null || output == null) {
+            LogHelper.logError(String.format("Required parameters missing for %s Recipe.", name));
+            return;
+        }
+        
+        CraftTweaker.ADDITIONS.add(new Add(name, new AssemblyRecipe(InputHelper.toStack(input), InputHelper.toStack(output)), list));
+    }
+    
+    private static class Add extends BaseListAddition<AssemblyRecipe> {
+        public Add(String name, AssemblyRecipe recipe, List<AssemblyRecipe> list) {
+            super(name, list);
+            recipes.add(recipe);
+        }
+
+        @Override
+        public String getRecipeInfo(AssemblyRecipe recipe) {
+            return LogHelper.getStackDescription(recipe.getOutput());
+        }
+    }
+    
+    public static void removeRecipe(String name, List<AssemblyRecipe> list, IIngredient output) {
+        CraftTweaker.REMOVALS.add(new Remove(name, list, output));
+    }
+    
+    private static class Remove extends BaseListRemoval<AssemblyRecipe> {
+    	private final IIngredient output;
+    	
+        public Remove(String name, List<AssemblyRecipe> list, IIngredient output) {
+            super(name, list);
+            this.output = output;
+        }
+        
+        @Override
+        public void apply() {
+        	addRecipes();
+        	
+        	super.apply();
+        }
+
+        private void addRecipes() {
+            for (AssemblyRecipe r : list) {
+                if (StackHelper.matches(output,  InputHelper.toIItemStack(r.getOutput()))) {
+                    recipes.add(r);
+                }
+            }
+            
+            if(recipes.isEmpty()) {
+            	LogHelper.logWarning(String.format("No %s Recipe found for %s. Command ignored!", name, LogHelper.getStackDescription(output)));
+            } else {
+            	LogHelper.logInfo(String.format("Found %d %s Recipe(s) for %s.", recipes.size(), name, LogHelper.getStackDescription(output)));
+            }
+		}
+
+		@Override
+        public String getRecipeInfo(AssemblyRecipe recipe) {
+            return LogHelper.getStackDescription(recipe.getOutput());
+        }
+		
+		@Override
+		public String describe() {
+			return String.format("Removing %s Recipe(s) for %s", this.name, LogHelper.getStackDescription(output));
+		}
+    }
+}

--- a/src/main/java/me/desht/pneumaticcraft/common/thirdparty/crafttweaker/handlers/PressureChamber.java
+++ b/src/main/java/me/desht/pneumaticcraft/common/thirdparty/crafttweaker/handlers/PressureChamber.java
@@ -1,0 +1,101 @@
+package me.desht.pneumaticcraft.common.thirdparty.crafttweaker.handlers;
+
+import static com.blamejared.mtlib.helpers.InputHelper.toStacks;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import com.blamejared.mtlib.helpers.InputHelper;
+import com.blamejared.mtlib.helpers.LogHelper;
+import com.blamejared.mtlib.helpers.StackHelper;
+import com.blamejared.mtlib.utils.BaseListAddition;
+import com.blamejared.mtlib.utils.BaseListRemoval;
+
+import crafttweaker.annotations.ModOnly;
+import crafttweaker.annotations.ZenRegister;
+import crafttweaker.api.item.IIngredient;
+import crafttweaker.api.item.IItemStack;
+import me.desht.pneumaticcraft.common.recipes.PressureChamberRecipe;
+import me.desht.pneumaticcraft.common.thirdparty.crafttweaker.CraftTweaker;
+import me.desht.pneumaticcraft.common.thirdparty.crafttweaker.util.RemoveAllRecipes;
+import stanhebben.zenscript.annotations.ZenClass;
+import stanhebben.zenscript.annotations.ZenMethod;
+
+@ZenClass("mods.pneumaticcraft.pressurechamber")
+@ModOnly("mtlib")
+@ZenRegister
+public class PressureChamber {
+	
+	public static final String name = "PneumaticCraft Pressure Chamber";
+	
+	
+    @ZenMethod
+    public static void addRecipe(IItemStack[] input, double pressure, IItemStack[] output, boolean asBlock)
+    {
+    	CraftTweaker.ADDITIONS.add(new Add(new PressureChamberRecipe(toStacks(input), (float) pressure, toStacks(output), asBlock)));
+    }
+    
+    @ZenMethod
+    public static void removeRecipe(IIngredient[] output)
+    {
+    	CraftTweaker.REMOVALS.add(new Remove(PressureChamberRecipe.chamberRecipes, output));
+    }
+    
+    @ZenMethod
+    public static void removeAllRecipes() {
+        CraftTweaker.REMOVALS.add(new RemoveAllRecipes<PressureChamberRecipe>(PressureChamber.name, PressureChamberRecipe.chamberRecipes));
+    }   
+    
+    private static class Add extends BaseListAddition<PressureChamberRecipe> {
+        public Add(PressureChamberRecipe recipe) {
+            super(PressureChamber.name, PressureChamberRecipe.chamberRecipes);
+            recipes.add(recipe);
+        }
+
+        @Override
+        public String getRecipeInfo(PressureChamberRecipe recipe) {
+            return LogHelper.getStackDescription(recipe.output[0]);
+        }
+    }
+    
+    private static class Remove extends BaseListRemoval<PressureChamberRecipe> {
+    	private final IIngredient[] output;
+    	
+        public Remove(List<PressureChamberRecipe> recipes, IIngredient[] output) {
+            super(PressureChamber.name, PressureChamberRecipe.chamberRecipes, recipes);
+            this.output = output;
+        }
+        
+        @Override
+        public void apply() {
+        	addRecipes();
+        	
+        	super.apply();
+        }
+        
+        private void addRecipes() {
+            for (PressureChamberRecipe r : list) {
+            	
+            	if(Stream.of(output).allMatch(o -> Stream.of(r.output).anyMatch(ro -> StackHelper.matches(o, InputHelper.toIItemStack(ro))))) {
+            		recipes.add(r);
+            	}
+            }
+            
+            if(recipes.isEmpty()) {
+            	LogHelper.logWarning(String.format("No %s Recipe found for %s. Command ignored!", name, LogHelper.getStackDescription(output)));
+            } else {
+            	LogHelper.logInfo(String.format("Found %d %s Recipe(s) for %s.", recipes.size(), name, LogHelper.getStackDescription(output)));
+            }
+		}
+        
+        @Override
+        public String getRecipeInfo(PressureChamberRecipe recipe) {
+            return LogHelper.getStackDescription(recipe.output[0]);
+        }
+        
+		@Override
+		public String describe() {
+			return String.format("Removing %s Recipe(s) for %s", this.name, LogHelper.getStackDescription(output[0]));
+		}
+    }
+}

--- a/src/main/java/me/desht/pneumaticcraft/common/thirdparty/crafttweaker/handlers/ThermopneumaticProcessingPlant.java
+++ b/src/main/java/me/desht/pneumaticcraft/common/thirdparty/crafttweaker/handlers/ThermopneumaticProcessingPlant.java
@@ -1,0 +1,109 @@
+package me.desht.pneumaticcraft.common.thirdparty.crafttweaker.handlers;
+
+import java.util.List;
+
+import com.blamejared.mtlib.helpers.InputHelper;
+import com.blamejared.mtlib.helpers.LogHelper;
+import com.blamejared.mtlib.helpers.StackHelper;
+import com.blamejared.mtlib.utils.BaseListAddition;
+import com.blamejared.mtlib.utils.BaseListRemoval;
+
+import crafttweaker.annotations.ModOnly;
+import crafttweaker.annotations.ZenRegister;
+import crafttweaker.api.item.IIngredient;
+import crafttweaker.api.item.IItemStack;
+import me.desht.pneumaticcraft.api.recipe.IThermopneumaticProcessingPlantRecipe;
+import me.desht.pneumaticcraft.common.recipes.AssemblyRecipe;
+import me.desht.pneumaticcraft.common.recipes.BasicThermopneumaticProcessingPlantRecipe;
+import me.desht.pneumaticcraft.common.recipes.PneumaticRecipeRegistry;
+import me.desht.pneumaticcraft.common.recipes.PressureChamberRecipe;
+import me.desht.pneumaticcraft.common.thirdparty.crafttweaker.CraftTweaker;
+import me.desht.pneumaticcraft.common.thirdparty.crafttweaker.util.RemoveAllRecipes;
+import net.minecraft.item.ItemStack;
+import crafttweaker.api.liquid.ILiquidStack;
+import stanhebben.zenscript.annotations.ZenClass;
+import stanhebben.zenscript.annotations.ZenMethod;
+
+@ZenClass("mods.pneumaticcraft.thermopneumaticprocessingplant")
+@ModOnly("mtlib")
+@ZenRegister
+public class ThermopneumaticProcessingPlant {
+	
+	public static final String name = "PneumaticCraft Thermopneumatic Processing Plant";
+	
+	@ZenMethod
+	public static void addRecipe(ILiquidStack liquidInput, IItemStack itemInput, double pressure, double temperature, ILiquidStack output) {
+		CraftTweaker.ADDITIONS.add(new Add(new BasicThermopneumaticProcessingPlantRecipe(InputHelper.toFluid(liquidInput), InputHelper.toStack(itemInput), InputHelper.toFluid(output), temperature, (float) pressure), output));
+	}
+
+	@ZenMethod
+	public static void addRecipe(IItemStack itemInput, double pressure, double temperature, ILiquidStack output) {
+		addRecipe(null, itemInput, pressure, temperature, output);
+	}
+
+	@ZenMethod
+    public static void removeRecipe(IIngredient output)
+    {
+		CraftTweaker.REMOVALS.add(new Remove(PneumaticRecipeRegistry.getInstance().thermopneumaticProcessingPlantRecipes, output));
+    }
+
+	@ZenMethod
+	public static void removeAllRecipes() {
+		CraftTweaker.REMOVALS.add(new RemoveAllRecipes<IThermopneumaticProcessingPlantRecipe>(name, PneumaticRecipeRegistry.getInstance().thermopneumaticProcessingPlantRecipes));
+	}
+	
+    private static class Add extends BaseListAddition<IThermopneumaticProcessingPlantRecipe> {
+    	private final ILiquidStack output;
+    	
+        public Add(IThermopneumaticProcessingPlantRecipe recipe, ILiquidStack output) {
+            super(ThermopneumaticProcessingPlant.name, PneumaticRecipeRegistry.getInstance().thermopneumaticProcessingPlantRecipes);
+            this.output = output;
+            recipes.add(recipe);
+        }
+
+        @Override
+        public String getRecipeInfo(IThermopneumaticProcessingPlantRecipe recipe) {
+            return LogHelper.getStackDescription(output);
+        }
+    }
+    
+    private static class Remove extends BaseListRemoval<IThermopneumaticProcessingPlantRecipe> {
+    	private final IIngredient output;
+    	
+        public Remove(List<IThermopneumaticProcessingPlantRecipe> list, IIngredient output) {
+            super(ThermopneumaticProcessingPlant.name, list);
+            this.output = output;
+        }
+        
+        @Override
+        public void apply() {
+        	addRecipes();
+        	
+        	super.apply();
+        }
+
+        private void addRecipes() {
+            for (IThermopneumaticProcessingPlantRecipe r : list) {
+                if (StackHelper.matches(output,  InputHelper.toILiquidStack(r.getRecipeOutput(null, ItemStack.EMPTY)))) {
+                    recipes.add(r);
+                }
+            }
+            
+            if(recipes.isEmpty()) {
+            	LogHelper.logWarning(String.format("No %s Recipe found for %s. Command ignored!", name, LogHelper.getStackDescription(output)));
+            } else {
+            	LogHelper.logInfo(String.format("Found %d %s Recipe(s) for %s.", recipes.size(), name, LogHelper.getStackDescription(output)));
+            }
+		}
+
+		@Override
+        public String getRecipeInfo(IThermopneumaticProcessingPlantRecipe recipe) {
+            return LogHelper.getStackDescription(output);
+        }
+		
+		@Override
+		public String describe() {
+			return String.format("Removing %s Recipe(s) for %s", this.name, LogHelper.getStackDescription(output));
+		}
+    }
+}

--- a/src/main/java/me/desht/pneumaticcraft/common/thirdparty/crafttweaker/util/RemoveAllRecipes.java
+++ b/src/main/java/me/desht/pneumaticcraft/common/thirdparty/crafttweaker/util/RemoveAllRecipes.java
@@ -1,0 +1,28 @@
+package me.desht.pneumaticcraft.common.thirdparty.crafttweaker.util;
+
+import java.util.List;
+
+import com.blamejared.mtlib.utils.BaseListRemoval;
+
+public class RemoveAllRecipes<T> extends BaseListRemoval<T> {
+
+	public RemoveAllRecipes(String name, List<T> list) {
+		super(name, list);
+	}
+	
+	@Override
+	public void apply() {
+		recipes.addAll(list);
+		super.apply();
+	}
+	
+	@Override
+	protected String getRecipeInfo(T recipe) {
+		return "";
+	}
+	
+	@Override
+	public String describe() {
+		return String.format("Removing all %s Recipe(s)", this.name);
+	}
+}

--- a/src/main/java/me/desht/pneumaticcraft/lib/ModIds.java
+++ b/src/main/java/me/desht/pneumaticcraft/lib/ModIds.java
@@ -17,4 +17,5 @@ public class ModIds {
     public static final String MCMP = "mcmultipart";
     public static final String TOP = "theoneprobe";
     public static final String JEI = "jei";
+    public static final String CRAFTTWEAKER = "crafttweaker";
 }


### PR DESCRIPTION
Added support for CraftTweaker / ZenScript for assembly, pressure chamber and thermopneumatic processing plant. Following commands are available:
```
// Asembly
mods.pneumaticcraft.assembly.addDrillRecipe(IItemStack input, IItemStack output);
mods.pneumaticcraft.assembly.addDrillLaserRecipe(IItemStack input, IItemStack output);
mods.pneumaticcraft.assembly.addLaserRecipe(IItemStack input, IItemStack output);
mods.pneumaticcraft.assembly.removeAllDrillRecipes();
mods.pneumaticcraft.assembly.removeAllDrillLaserRecipes();
mods.pneumaticcraft.assembly.removeAllLaserRecipes();
mods.pneumaticcraft.assembly.removeAllRecipes();
mods.pneumaticcraft.assembly.removeDrillRecipe(IIngredient output);
mods.pneumaticcraft.assembly.removeDrillLaserRecipe(IIngredient output);
mods.pneumaticcraft.assembly.removeLaserRecipe(IIngredient output);

// Pressure Chamber
mods.pneumaticcraft.pressurechamber.addRecipe(IItemStack[] input, double pressure, IItemStack[] output, boolean asBlock);
mods.pneumaticcraft.pressurechamber.removeRecipe(IIngredient[] output);
mods.pneumaticcraft.pressurechamber.removeAllRecipes();

// Thermopneumatic Processing Plant
mods.pneumaticcraft.thermopneumaticprocessingplant.addRecipe(IItemStack itemInput, double pressure, double temperature, ILiquidStack output);
mods.pneumaticcraft.thermopneumaticprocessingplant.addRecipe(ILiquidStack liquidInput, IItemStack itemInput, double pressure, double temperature, ILiquidStack output);
mods.pneumaticcraft.thermopneumaticprocessingplant.removeRecipe(IIngredient output);
mods.pneumaticcraft.thermopneumaticprocessingplant.removeAllRecipes();
```

