### PR TITLE
Fixes AE2 integration

### DIFF
--- a/src/main/java/me/desht/pneumaticcraft/common/semiblock/SemiBlockRequester.java
+++ b/src/main/java/me/desht/pneumaticcraft/common/semiblock/SemiBlockRequester.java
@@ -179,7 +179,7 @@ public class SemiBlockRequester extends SemiBlockLogistics implements ISpecificR
 
         if(!world.isRemote) {
             if(needToCheckForInterface) {
-                if(Loader.isModLoaded(ModIds.AE2) && !world.isRemote && aeMode && gridNode == null) {
+                if(Loader.isModLoaded(ModIds.AE2) && aeMode && gridNode == null) {
                     needToCheckForInterface = checkForInterface();
                 } else {
                 	needToCheckForInterface = false;
@@ -238,7 +238,7 @@ public class SemiBlockRequester extends SemiBlockLogistics implements ISpecificR
 
     @Optional.Method(modid = ModIds.AE2)
     public boolean isPlacedOnInterface(){
-        return getTileEntity() != null && AEApi.instance().definitions().blocks().iface().maybeBlock().get() == getTileEntity().getBlockType();
+        return AEApi.instance().definitions().blocks().iface().maybeEntity().map(e -> e.isInstance(getTileEntity())).orElse(false);
     }
 
     @Optional.Method(modid = ModIds.AE2)
@@ -249,7 +249,7 @@ public class SemiBlockRequester extends SemiBlockLogistics implements ISpecificR
                 if(((IGridHost)te).getGridNode(null) == null) return true;
                 if(getGridNode(null) == null) return true;
                 try {
-                    AEApi.instance().grid().createGridConnection(getGridNode(null), ((IGridHost)te).getGridNode(null));
+                    AEApi.instance().grid().createGridConnection(((IGridHost)te).getGridNode(null), getGridNode(null));
                 } catch(FailedConnectionException e) {
                     Log.error("Couldn't connect to an ME Interface!");
                     e.printStackTrace();


### PR DESCRIPTION
Follow up for #32.

Changed the order for creating the grid connection. This is actually important in this case to treat the first parameter as source with an existing grid and the second as destination. Otherwise the frame will create it's own small grid and force the attached interface to join the newly created grid without joining both. This is mostly necessary due to being such a special case with the frame not being part of the real world as well as the normal use would be to connect the current node to something else. But here we really need to create a connection from the interface to the frame, not the other way.

Just in case it ever happens and someone disables the interface, I updated `isPlacedOnInterface` to make use of the provided optional instead of an unconditional `get()` causing a crash.

Also removed the superfluous `!world.isRemote` in `update()` as this is already covered by the outer `if`

---
Switched order for createGridConnection to let it join a grid instead creating a new one.
Removed superfluous isRemote check.
Updated checkForInterface to avoid crashes should the interface be disabled.