### PR TITLE
Fixes oversending with AE2 integration.

### DIFF
--- a/src/main/java/me/desht/pneumaticcraft/common/semiblock/SemiBlockRequester.java
+++ b/src/main/java/me/desht/pneumaticcraft/common/semiblock/SemiBlockRequester.java
@@ -374,14 +374,12 @@ public class SemiBlockRequester extends SemiBlockLogistics implements ISpecificR
     @Optional.Method(modid = ModIds.AE2)
     public void onRequestChange(ICraftingGrid grid, IAEItemStack aeStack){
         craftingGrid = grid;
-        ItemStack stack = aeStack.createItemStack();
         int freeSlot = -1;
         for(int i = 0; i < getFilters().getSlots(); i++) {
             ItemStack s = getFilters().getStackInSlot(i);
             if(!s.isEmpty()) {
-                if(stack.isItemEqual(s)) {
-                    s.setCount( stack.getCount() );
-                    if(s.getCount() == 0) getFilters().setStackInSlot(i, ItemStack.EMPTY);
+                if(aeStack.isSameType(s)) {
+                    s.setCount( (int) aeStack.getStackSize() );
                     return;
                 }
             } else if(freeSlot == -1) {
@@ -389,7 +387,7 @@ public class SemiBlockRequester extends SemiBlockLogistics implements ISpecificR
             }
         }
         if(freeSlot >= 0) {
-            getFilters().setStackInSlot(freeSlot, stack.copy());
+            getFilters().setStackInSlot(freeSlot, aeStack.createItemStack());
         }
     }
 


### PR DESCRIPTION
This is caused by minecraft no longer liking `ItemStack`s with a size 0. Thus the filter gets never set to 0 until the fallback solution via `IStackWatcherHost#onStackChange()` triggers.

I removed creating the `ItemStack` copy just for comparion and using the one provided by `IAEItemStack`. Further it also makes use of minecraft considering an itemstack with a size of 0 to be empty, so it no longer sets it explicitly to `ItemStack.EMPTY`. This should work as long as there is no identity comparsion with `ItemStack.EMPTY`. Or using the raw item for various reason. Any normal use should make no difference between an empty itemstack and the actual `ItemStack.EMPTY` instance.

Casting a `long` to `int` is usually not ideal. But as long as the system is still crafting it will constantly refresh it until it reaches zero. So it should be fine. Otherwise requesting over 2 billion items via logistic drones probably has already other issues. Similar should issues arise with exceeding the maxStackSize. It could be simply capped to it and refreshed until done.

The only real issue I can currently see apart from unknown bugs are crafting requests exceeding 27 different items. In this case it will only add the initial 27 items to the requested items, any other will be ignored and also not refreshes as there will be no change later to update it. This somewhat overlaps with even requesting items currently not present in the logistics network. So adding them to the network should result in the drone moving it to the AE system, even if there is already another crafting task running in another machine. Not that this will be an issue besides the ME network having more items than requested to craft.
But I doubt this actually being an issue which needs immediate solving.

FYI. A quick search found [PressureChamberVacuumEnchantHandler.java#L54](https://github.com/desht/pnc-repressurized/blob/c8395dfd0c5a62d1cb18912bfb09db78770e5c9a/src/main/java/me/desht/pneumaticcraft/common/recipes/PressureChamberVacuumEnchantHandler.java#L54) using `==` and not `isEmpty()`