### PR TITLE
Update IGW-Mod version.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -30,4 +30,4 @@ top_version=1.12-1.4.18-10
 crafttweaker_version=4.0.9.285
 mtlib_version=3.0.1.3
 ae2_version=rv5-stable-1
-igwmod_version=1.4.1-8
+igwmod_version=1.4.1-9


### PR DESCRIPTION
Currently wikipages cannot be retrieved successfully, the block/item pages will need to be renamed to the new_item_name format for this. I will do this later.

There also was a dynamic link between programming widgets and wikipages by progwidget id, however those IDs are in camelcasing atm. The easiest solution to make this work is probably request the lowercased id from IGW-mod. I wouldn't change the ID's of progwidgets to the_underscore_format, because the 'old' id's still could be used in some old drone program pastebins that would stop working when the id's would change.